### PR TITLE
Allow additional content after the sortable fields in the sorters description.

### DIFF
--- a/functions/parameter-filter-description-check.js
+++ b/functions/parameter-filter-description-check.js
@@ -29,7 +29,7 @@ module.exports = (targetVal, _opts) => {
   }
 
   let i = 2
-  while (i < parts.length && parts[i].includes(':')) {
+  while (i < parts.length && parts[i].includes('**: *')) {
     const filters = parts[i].split(':')
     const property = filters[0]
     const operations = filters[1].trim()

--- a/functions/parameter-sorter-description-check.js
+++ b/functions/parameter-sorter-description-check.js
@@ -50,7 +50,7 @@ module.exports = (targetVal, _opts) => {
   }
 
   // Check if the properties are comma separated
-  regex = new RegExp('^\\*\\*[a-z]+(,\\s[a-z]+)*\\*\\*$')
+  regex = new RegExp('^\\*\\*[a-zA-Z.]+(,\\s[a-zA-Z.]+)*\\*\\*$')
   if (!regex.test(properties)) {
     return [
       {

--- a/functions/tests/parameter-sorter-description-check-test.js
+++ b/functions/tests/parameter-sorter-description-check-test.js
@@ -4,7 +4,7 @@ let ruleNumber = 325;
 
 let validSorterDescription = `Sort results using the standard syntax described in [V3 API Standard Collection Parameters](https://developer.sailpoint.com/idn/api/standard-collection-parameters#sorting-results)
 
-Sorting is supported for the following fields: **name, identity.manager, modified**`;
+Sorting is supported for the following fields: **owner.name, name, identity.manager, modified, identityId**`;
 
 let badKeyForFields = `Sort results using the standard syntax described in [V3 API Standard Collection Parameters](https://developer.sailpoint.com/idn/api/standard-collection-parameters#sorting-results)
 


### PR DESCRIPTION
Before this fix, the following description for `sorters` would cause a linter error due to additional text at the end of the description.

```yaml
- in: query
      name: sorters
      schema:
        type: string
        format: comma-separated
      required: false
      description: >-
        Sort results using the standard syntax described in [V3 API Standard Collection Parameters](https://developer.sailpoint.com/idn/api/standard-collection-parameters#sorting-results)


        Sorting is supported for the following fields: **name, created**


        The default sorter is `name`.
```

This commit will allow additional text after the first two lines so we can provide more context about sorters.