### PR TITLE
APIMGMT-1896: Add validation rules for backOffConfig in gateway-ruleset.yaml

### DIFF
--- a/packages/gateway-rulesets/gateway-ruleset.yaml
+++ b/packages/gateway-rulesets/gateway-ruleset.yaml
@@ -215,3 +215,64 @@ rules:
     severity: error
     then:
       function: check-dynamic-rate-limit
+
+  gateway-route-back-off-config-must-have-valid-properties:
+    given: $.sp-gateway.routes.*.backOffConfig
+    severity: error
+    then:
+      function: check-field-names
+      functionOptions:
+        value: "backOffConfig"
+
+  gateway-route-back-off-config-enabled-must-be-boolean:
+    message: "Invalid value for backOffConfig.enabled. Must be a boolean."
+    given: "$.sp-gateway.routes.*.backOffConfig.enabled"
+    severity: error
+    then:
+      function: schema
+      functionOptions:
+        schema:
+          type: boolean
+
+  gateway-route-back-off-config-integer-fields-must-be-positive:
+    message: "Invalid value for backOffConfig integer field. Must be a positive integer."
+    given: "$.sp-gateway.routes.*.backOffConfig"
+    severity: error
+    then:
+      - field: intervalThreshold
+        function: schema
+        functionOptions:
+          schema:
+            type: integer
+            minimum: 1
+      - field: violationWindow
+        function: schema
+        functionOptions:
+          schema:
+            type: integer
+            minimum: 1
+      - field: tierMemoryWindow
+        function: schema
+        functionOptions:
+          schema:
+            type: integer
+            minimum: 1
+      - field: redisTimeoutMs
+        function: schema
+        functionOptions:
+          schema:
+            type: integer
+            minimum: 1
+
+  gateway-route-back-off-config-tiers-must-be-valid:
+    message: "Invalid value for backOffConfig.tiers. Must be an array of positive integers."
+    given: "$.sp-gateway.routes.*.backOffConfig.tiers"
+    severity: error
+    then:
+      function: schema
+      functionOptions:
+        schema:
+          type: array
+          items:
+            type: integer
+            minimum: 1

--- a/packages/gateway-rulesets/src/check-field-names.ts
+++ b/packages/gateway-rulesets/src/check-field-names.ts
@@ -1,6 +1,7 @@
 // Copyright (c) 2026. SailPoint Technologies, Inc. All rights reserved.
 import { createOptionalContextRulesetFunction } from "./createOptionalContextRulesetFunction.js";
 import {
+    BackOffConfigKeys,
     DynamicRateLimitCommonConfigKeys,
     Route, RouteDynamicRateLimitConfigKeys, RouteKeys, SubrouteKeys, VersionDetailsKeys
 } from "./types.js";
@@ -35,6 +36,9 @@ export default createOptionalContextRulesetFunction(
                 new Map<string, Object>(Object.entries(objectToValidate)).forEach((details, id) => {
                     CheckInterfaceForField(id, details, VersionDetailsKeys, errors)
                 })
+                break
+            case "backOffConfig":
+                CheckInterfaceForField("backOffConfig", objectToValidate, BackOffConfigKeys, errors)
                 break
             case "dynamicRateLimit":
                 new Map<string, Object>(Object.entries(objectToValidate)).forEach((rateLimitConfig, routeId) => {

--- a/packages/gateway-rulesets/src/types.ts
+++ b/packages/gateway-rulesets/src/types.ts
@@ -106,6 +106,29 @@ export interface Route {
 
     // Subroutes is a map of subroutes and their properties for a given route ID
     subroutes?: Map<string, Subroute>;
+
+    // BackOffConfig defines the adaptive backoff configuration for this route. (optional)
+    backOffConfig?: BackOffConfig;
+}
+
+export interface BackOffConfig {
+    // Whether backoff is enabled for this route.
+    enabled?: boolean;
+
+    // IntervalThreshold is the number of distinct violated rate-limit intervals before backoff triggers.
+    intervalThreshold?: number;
+
+    // Tiers defines the backoff duration per escalation tier, in seconds.
+    tiers?: number[];
+
+    // ViolationWindow is the time window in which violated intervals are counted, in seconds.
+    violationWindow?: number;
+
+    // TierMemoryWindow is how long a tier is remembered after expiry, in seconds.
+    tierMemoryWindow?: number;
+
+    // RedisTimeoutMs is the max time allowed per Redis backoff operation, in milliseconds.
+    redisTimeoutMs?: number;
 }
 
 export interface VersionDetails {
@@ -160,6 +183,7 @@ export type KeysEnum<T> = { [P in keyof Required<T>]: true };
 const RouteKeyType: KeysEnum<Route> = {
     additionalVersions: true,
     apiState: true,
+    backOffConfig: true,
     circuitBreakerEnabled: true,
     circuitBreakerInterval: true,
     circuitBreakerMaxRequests: true,
@@ -229,8 +253,18 @@ const DynamicRateLimitCommonConfigKeyType: KeysEnum<DynamicRateLimitCommonConfig
     rateLimitIntervalSeconds: true
 }
 
+const BackOffConfigKeyType: KeysEnum<BackOffConfig> = {
+    enabled: true,
+    intervalThreshold: true,
+    tiers: true,
+    violationWindow: true,
+    tierMemoryWindow: true,
+    redisTimeoutMs: true,
+}
+
 export const RouteKeys = Object.keys(RouteKeyType)
 export const SubrouteKeys = Object.keys(SubroutesKeyType)
 export const VersionDetailsKeys = Object.keys(VersionDetailsKeyType)
 export const RouteDynamicRateLimitConfigKeys = Object.keys(RouteDynamicRateLimitConfigKeyType)
 export const DynamicRateLimitCommonConfigKeys = Object.keys(DynamicRateLimitCommonConfigKeyType)
+export const BackOffConfigKeys = Object.keys(BackOffConfigKeyType)

--- a/packages/test-files/sp-gateway-routes.yaml
+++ b/packages/test-files/sp-gateway-routes.yaml
@@ -53,3 +53,20 @@ sp-gateway:
       routeType: "prefix"
       stripPrefix: true
       apiState: "public"
+
+    # Intentional violations for backOffConfig rules
+    - id: "back-off-config-test"
+      path: "/back-off-config-test"
+      service: "identity"
+      versionStart: 2024
+      routeType: "prefix"
+      stripPrefix: true
+      apiState: "public"
+      backOffConfig:
+        enabled: "yes"          # violation: must be boolean, not string
+        intervalThreshold: -5   # violation: must be a positive integer
+        tiers: [30, "sixty", 90] # violation: tiers must be an array of integers
+        violationWindow: 0      # violation: must be >= 1
+        tierMemoryWindow: 300
+        redisTimeoutMs: 50
+        unknownField: "oops"    # violation: unknown property


### PR DESCRIPTION
Adds Spectral validation for the new optional backOffConfig object on gateway routes and wires it into the existing field-name checker, allowing only documented keys.

Test: 
```
/Users/victor.mancera/code/api-linter/packages/test-files/sp-gateway-routes.yaml

  37:7   error  gateway-route-version-details-map-keys-must-not-exceed-version-end   (pre-existente)
  61:21  error  gateway-route-must-have-version-start-in-order                       (pre-existente)
  65:21  error  gateway-route-back-off-config-must-have-valid-properties             backOffConfig has an invalid field: unknownField
  66:18  error  gateway-route-back-off-config-enabled-must-be-boolean                Invalid value for backOffConfig.enabled. Must be a boolean.
  67:28  error  gateway-route-back-off-config-integer-fields-must-be-positive        Invalid value for backOffConfig integer field. Must be a positive integer.
  68:21  error  gateway-route-back-off-config-tiers-must-be-valid                    Invalid value for backOffConfig.tiers. Must be an array of positive integers.
  69:26  error  gateway-route-back-off-config-integer-fields-must-be-positive        Invalid value for backOffConfig integer field. Must be a positive integer.

✖ 7 problems (7 errors, 0 warnings, 0 infos, 0 hints)
```