### PR TITLE
APIMGMT-1989: Add method-specific rate limiting configuration to Subroute. 

### DIFF
--- a/packages/gateway-rulesets/src/types.ts
+++ b/packages/gateway-rulesets/src/types.ts
@@ -157,6 +157,17 @@ export interface Subroute {
     versions?: string[];
     rateLimit?: number;
     rateLimitIntervalSeconds?: number;
+    // Per-method rate limiting configuration for this subroute. (optional)
+    methodConfig?: MethodConfig[];
+}
+
+export interface MethodConfig {
+    // HTTP methods this rate limit applies to, for example ["GET"], ["POST"]
+    methods: string[];
+    // Number of requests allowed per rateLimitIntervalSeconds
+    rateLimit: number;
+    // Interval in seconds for rate limiting
+    rateLimitIntervalSeconds: number;
 }
 
 export interface DynamicRateLimitConfig {
@@ -237,7 +248,8 @@ const SubroutesKeyType: KeysEnum<Subroute> = {
     methods: true,
     versions: true,
     rateLimit: true,
-    rateLimitIntervalSeconds: true
+    rateLimitIntervalSeconds: true,
+    methodConfig: true
 }
 
 const RouteDynamicRateLimitConfigKeyType: KeysEnum<RouteDynamicRateLimitConfig> = {


### PR DESCRIPTION
Manual test: 

```
node --input-type=module -e '
import { SubrouteKeys } from "./functions/types.js";
import { CheckInterfaceForField } from "./functions/utils.js";

const subroutes = {
  "/subroute": {
    rateLimit: 5,
    rateLimitIntervalSeconds: 10,
    methodConfig: [
      { methods: ["GET"], rateLimit: 10, rateLimitIntervalSeconds: 10 },
      { methods: ["POST"], rateLimit: 3, rateLimitIntervalSeconds: 10 }
    ]
  }
};

let errors = [];
for (const [id, sub] of Object.entries(subroutes)) {
  CheckInterfaceForField(id, sub, SubrouteKeys, errors);
}
console.log("SubrouteKeys:", SubrouteKeys);
console.log("Errors:", errors);
'

Out: 

SubrouteKeys: [
  'rights',
  'methods',
  'versions',
  'rateLimit',
  'rateLimitIntervalSeconds',
  'methodConfig'
]
Errors: []
```