### PR TITLE
APIMGMT-2097: updated linter to match new API versioning strategy

### DIFF
--- a/packages/gateway-rulesets/gateway-ruleset.yaml
+++ b/packages/gateway-rulesets/gateway-ruleset.yaml
@@ -1,5 +1,5 @@
 functions: [gateway-test,
-  check-version-start,check-unique-id,check-version-start-order,check-path-documentation,check-latest-version-override,check-version-details-map-vs-version-end,check-subroutes,check-dynamic-rate-limit,check-field-names]
+  check-version-start,check-unique-id,check-version-in-id,check-version-in-id-matches-path,check-strip-prefix-path-matches-path,check-version-start-order,check-path-documentation,check-latest-version-override,check-version-details-map-vs-version-end,check-subroutes,check-dynamic-rate-limit,check-field-names]
 rules:
   gateway-route-must-have-valid-properties:
     given: $.sp-gateway.routes.*
@@ -17,13 +17,13 @@ rules:
       functionOptions:
         value: "subroute"
 
-  gateway-version-details-must-have-valid-properties:
-    given: $.sp-gateway.routes.*.versionDetailsMap
-    severity: error
-    then:
-      function: check-field-names
-      functionOptions:
-        value: "versionDetail"
+#  gateway-version-details-must-have-valid-properties:
+#    given: $.sp-gateway.routes.*.versionDetailsMap
+#    severity: error
+#    then:
+#      function: check-field-names
+#      functionOptions:
+#        value: "versionDetail"
 
   gateway-dynamic-rate-limit-must-have-valid-properties:
     given: $.dynamic-rate-limits.*
@@ -45,16 +45,16 @@ rules:
       - field: id
         function: truthy
 
-  gateway-route-additional-versions-must-be-valid:
-    message: "Invalid value specified for additionalVersion. Must be beta or v3."
-    given: $.sp-gateway.routes.*.additionalVersions.*
-    severity: error
-    then: 
-      function: enumeration
-      functionOptions:
-        values:
-          - beta
-          - v3
+#  gateway-route-additional-versions-must-be-valid:
+#    message: "Invalid value specified for additionalVersion. Must be beta or v3."
+#    given: $.sp-gateway.routes.*.additionalVersions.*
+#    severity: error
+#    then:
+#      function: enumeration
+#      functionOptions:
+#        values:
+#          - beta
+#          - v3
   gateway-route-api-state-must-be-valid:
     message: "Invalid value for apiState. Valid value is one of private, limited-preview, public-preview and public."
     given: $.sp-gateway.routes.*
@@ -69,19 +69,19 @@ rules:
           - public-preview
           - public
 
-  gateway-route-api-state-in-version-details-map-must-be-valid:
-    message: "Invalid value for apiState. Valid value is one of private, limited-preview, public-preview and public."
-    given: $.sp-gateway.routes.*.versionDetailsMap.*
-    severity: error
-    then:
-      - field: apiState
-        function: enumeration
-        functionOptions:
-          values:
-            - private
-            - limited-preview
-            - public-preview
-            - public
+#  gateway-route-api-state-in-version-details-map-must-be-valid:
+#    message: "Invalid value for apiState. Valid value is one of private, limited-preview, public-preview and public."
+#    given: $.sp-gateway.routes.*.versionDetailsMap.*
+#    severity: error
+#    then:
+#      - field: apiState
+#        function: enumeration
+#        functionOptions:
+#          values:
+#            - private
+#            - limited-preview
+#            - public-preview
+#            - public
 
   gateway-route-route-type-must-be-valid:
     message: "Invalid value for routeType. Valid value is one of prefix and path."
@@ -95,12 +95,12 @@ rules:
             - prefix
             - path
 
-  gateway-route-must-have-valid-version-start:
-    given: $.sp-gateway.routes.*
-    severity: error
-    then:
-      - field: versionStart
-        function: check-version-start
+#  gateway-route-must-have-valid-version-start:
+#    given: $.sp-gateway.routes.*
+#    severity: error
+#    then:
+#      - field: versionStart
+#        function: check-version-start
 
   gateway-route-must-have-unique-id:
     given: $.sp-gateway.routes.*
@@ -109,12 +109,31 @@ rules:
       - field: id
         function: check-unique-id
 
-  gateway-route-must-have-version-start-in-order:
+  gateway-route-must-have-version-in-id:
     given: $.sp-gateway.routes.*
     severity: error
     then:
-      - field: versionStart
-        function: check-version-start-order
+      - field: id
+        function: check-version-in-id
+
+  gateway-route-id-and-path-must-have-matching-version:
+    given: $.sp-gateway.routes.*
+    severity: error
+    then:
+      - function: check-version-in-id-matches-path
+
+  gateway-route-path-must-start-with-strip-prefix-path:
+    given: $.sp-gateway.routes.*
+    severity: error
+    then:
+      - function: check-strip-prefix-path-matches-path
+
+#  gateway-route-must-have-version-start-in-order:
+#    given: $.sp-gateway.routes.*
+#    severity: error
+#    then:
+#      - field: versionStart
+#        function: check-version-start-order
 
   # gateway-route-must-have-path-documentation:
   #   given: $.sp-gateway.routes.*
@@ -165,14 +184,14 @@ rules:
         schema:
           type: boolean
 
-  gateway-route-allowed-fields-in-version-details-map:
-    message: "Invalid field in versionDetailsMap. Must be a valid api version e.g. beta, v3 or v20XX"
-    severity: error
-    given: "$.sp-gateway.routes.*.versionDetailsMap.*~"
-    then:
-      - function: pattern
-        functionOptions:
-          "match" : "^beta$|^v3$|^v(202[4-9]|20[3-9][0-9]|2[1-9][0-9]{2})$"
+#  gateway-route-allowed-fields-in-version-details-map:
+#    message: "Invalid field in versionDetailsMap. Must be a valid api version e.g. beta, v3 or v20XX"
+#    severity: error
+#    given: "$.sp-gateway.routes.*.versionDetailsMap.*~"
+#    then:
+#      - function: pattern
+#        functionOptions:
+#          "match" : "^beta$|^v3$|^v(202[4-9]|20[3-9][0-9]|2[1-9][0-9]{2})$"
 
 
   # check-on-prefix-routes-only:
@@ -190,19 +209,19 @@ rules:
   #     functionOptions:
   #       rule: 403
 
-  gateway-route-latest-version-override-must-be-valid:
-    message: "latestVersionOverride must be a valid version and not greater than endVersion"
-    given: $.sp-gateway.routes.*
-    severity: error
-    then:
-      function: check-latest-version-override
+#  gateway-route-latest-version-override-must-be-valid:
+#    message: "latestVersionOverride must be a valid version and not greater than endVersion"
+#    given: $.sp-gateway.routes.*
+#    severity: error
+#    then:
+#      function: check-latest-version-override
 
-  gateway-route-version-details-map-keys-must-not-exceed-version-end:
-    message: "{{error}}"
-    given: $.sp-gateway.routes.*
-    severity: error
-    then:
-      function: check-version-details-map-vs-version-end
+#  gateway-route-version-details-map-keys-must-not-exceed-version-end:
+#    message: "{{error}}"
+#    given: $.sp-gateway.routes.*
+#    severity: error
+#    then:
+#      function: check-version-details-map-vs-version-end
 
   gateway-route-check-subroutes:
     given: $.sp-gateway.routes

--- a/packages/gateway-rulesets/src/check-field-names.ts
+++ b/packages/gateway-rulesets/src/check-field-names.ts
@@ -3,7 +3,7 @@ import { createOptionalContextRulesetFunction } from "./createOptionalContextRul
 import {
     BackOffConfigKeys,
     DynamicRateLimitCommonConfigKeys,
-    Route, RouteDynamicRateLimitConfigKeys, RouteKeys, SubrouteKeys, VersionDetailsKeys
+    Route, RouteDynamicRateLimitConfigKeys, RouteKeys, SubrouteKeys
 } from "./types.js";
 import {CheckInterfaceForField} from "./utils.js";
 
@@ -32,11 +32,11 @@ export default createOptionalContextRulesetFunction(
                     CheckInterfaceForField(id, subroute, SubrouteKeys, errors)
                 })
                 break
-            case "versionDetail":
-                new Map<string, Object>(Object.entries(objectToValidate)).forEach((details, id) => {
-                    CheckInterfaceForField(id, details, VersionDetailsKeys, errors)
-                })
-                break
+            // case "versionDetail":
+            //     new Map<string, Object>(Object.entries(objectToValidate)).forEach((details, id) => {
+            //         CheckInterfaceForField(id, details, VersionDetailsKeys, errors)
+            //     })
+            //     break
             case "backOffConfig":
                 CheckInterfaceForField("backOffConfig", objectToValidate, BackOffConfigKeys, errors)
                 break

--- a/packages/gateway-rulesets/src/check-latest-version-override.ts
+++ b/packages/gateway-rulesets/src/check-latest-version-override.ts
@@ -1,49 +1,49 @@
-import { createOptionalContextRulesetFunction } from "./createOptionalContextRulesetFunction.js";
-import { Route } from "./types.js";
-
-function isValidVersion(version: number): boolean {    
-    return version === 0 || (Number.isInteger(version) && version >= 2024);
-}
-
-function compareVersions(version1: number, version2: number): number {    
-    return version1 - version2;
-}
-
-export default createOptionalContextRulesetFunction(
-    {
-        input: null,
-        options: {
-        },
-    },
-    (targetVal: Route, options: { }) => {
-        let results = [];
-        
-        if (targetVal.latestVersionOverride !== undefined) {
-            const latestVersion = targetVal.latestVersionOverride;
-            
-            if (!isValidVersion(latestVersion)) {
-                results.push({
-                    message: `latestVersionOverride "${latestVersion}" is not a valid version. Must be 0 for non-versioned APIs or a year >= 2024.`
-                });
-            }
-            
-            if (targetVal.versionEnd !== undefined) {
-                const endVersion = targetVal.versionEnd;
-                
-                if (!isValidVersion(endVersion)) {
-                    results.push({
-                        message: `versionEnd "${endVersion}" is not a valid version. Must be 0 for non-versioned APIs or a year >= 2024.`
-                    });
-                } else {
-                    if (isValidVersion(latestVersion) && compareVersions(latestVersion, endVersion) > 0) {
-                        results.push({
-                            message: `latestVersionOverride "${latestVersion}" cannot be greater than versionEnd "${endVersion}"`
-                        });
-                    }
-                }
-            }
-        }
-        
-        return results;
-    },
-);
+// import { createOptionalContextRulesetFunction } from "./createOptionalContextRulesetFunction.js";
+// import { Route } from "./types.js";
+//
+// function isValidVersion(version: number): boolean {
+//     return version === 0 || (Number.isInteger(version) && version >= 2024);
+// }
+//
+// function compareVersions(version1: number, version2: number): number {
+//     return version1 - version2;
+// }
+//
+// export default createOptionalContextRulesetFunction(
+//     {
+//         input: null,
+//         options: {
+//         },
+//     },
+//     (targetVal: Route, options: { }) => {
+//         let results = [];
+//
+//         if (targetVal.latestVersionOverride !== undefined) {
+//             const latestVersion = targetVal.latestVersionOverride;
+//
+//             if (!isValidVersion(latestVersion)) {
+//                 results.push({
+//                     message: `latestVersionOverride "${latestVersion}" is not a valid version. Must be 0 for non-versioned APIs or a year >= 2024.`
+//                 });
+//             }
+//
+//             if (targetVal.versionEnd !== undefined) {
+//                 const endVersion = targetVal.versionEnd;
+//
+//                 if (!isValidVersion(endVersion)) {
+//                     results.push({
+//                         message: `versionEnd "${endVersion}" is not a valid version. Must be 0 for non-versioned APIs or a year >= 2024.`
+//                     });
+//                 } else {
+//                     if (isValidVersion(latestVersion) && compareVersions(latestVersion, endVersion) > 0) {
+//                         results.push({
+//                             message: `latestVersionOverride "${latestVersion}" cannot be greater than versionEnd "${endVersion}"`
+//                         });
+//                     }
+//                 }
+//             }
+//         }
+//
+//         return results;
+//     },
+// );

--- a/packages/gateway-rulesets/src/check-strip-prefix-path-matches-path.ts
+++ b/packages/gateway-rulesets/src/check-strip-prefix-path-matches-path.ts
@@ -1,0 +1,20 @@
+import { createOptionalContextRulesetFunction } from "./createOptionalContextRulesetFunction.js";
+import {Route} from "./types.js";
+
+export default createOptionalContextRulesetFunction(
+    {
+        input: null,
+        options: {
+        },
+    },
+    (route: Route, options: {}) => {
+        let results = [];
+        if (route.stripPrefix && route.stripPrefixPath && !route.path.startsWith(route.stripPrefixPath)) {
+            results.push({
+                message: `stripPrefixPath must match path when stripPrefix is true`
+            });
+        }
+        return results;
+    },
+);
+

--- a/packages/gateway-rulesets/src/check-subroutes.ts
+++ b/packages/gateway-rulesets/src/check-subroutes.ts
@@ -36,34 +36,6 @@ export default createOptionalContextRulesetFunction(
                     }
                 })
 
-                const versionStart: number = route.versionStart ?? 0
-                const versionEnd: number = route.versionEnd ?? 0
-                subroute.versions?.forEach(version => {
-                    if (legacyVersions.includes(version)) {
-                        if (!route.additionalVersions?.includes(version)) {
-                            results.push({
-                                message: `subroute ${name} has a version that is not included in the route's additionalVersions array: ${version}`
-                            });
-                        }
-                    } else if (versionPattern.test(version) && versionStart > 0) { // check versions that start with v (eg. v2025)
-
-                        const versionNum = version.substring(version.indexOf("v") + 1)
-                        if (Number.parseInt(versionNum) < versionStart) {
-                            results.push({
-                                message: `subroute ${name} has an invalid version [lower than versionStart]: ${version}`
-                            });
-                        } else if (versionEnd > 0 && Number.parseInt(versionNum) > versionEnd) {
-                            results.push({
-                                message: `subroute ${name} has an invalid version [greater than versionEnd]: ${version}`
-                            });
-                        }
-                    } else {
-                        results.push({
-                            message: `subroute ${name} has a version that could not be parsed: ${version}`
-                        });
-                    }
-                })
-
                 if (subroute.rateLimit === undefined && (subroute.rights === undefined || subroute.rights.length == 0)) {
                     results.push({
                         message: `subroute ${name} must have either an array of rights or a defined rate limit`

--- a/packages/gateway-rulesets/src/check-version-details-map-vs-version-end.ts
+++ b/packages/gateway-rulesets/src/check-version-details-map-vs-version-end.ts
@@ -1,44 +1,44 @@
-// Copyright (c) 2026. SailPoint Technologies, Inc. All rights reserved.
-import { createOptionalContextRulesetFunction } from "./createOptionalContextRulesetFunction.js";
-import { Route } from "./types.js";
-
-const V_YEAR_KEY = /^v(\d{4})$/;
-
-/**
- * Returns the numeric year for keys like v2026, or null for beta, v3, etc.
- */
-function yearFromVersionDetailsKey(key: string): number | null {
-  const m = V_YEAR_KEY.exec(key);
-  return m ? parseInt(m[1], 10) : null;
-}
-
-export default createOptionalContextRulesetFunction(
-  {
-    input: null,
-    options: {},
-  },
-  (targetVal: Route) => {
-    const results: { message: string }[] = [];
-
-    if (targetVal.versionEnd === undefined || targetVal.versionDetailsMap === undefined) {
-      return results;
-    }
-
-    const endVersion = targetVal.versionEnd;
-    if (endVersion === 0) {
-      return results;
-    }
-
-    const map = targetVal.versionDetailsMap as unknown as Record<string, unknown>;
-    for (const key of Object.keys(map)) {
-      const year = yearFromVersionDetailsKey(key);
-      if (year !== null && year > endVersion) {
-        results.push({
-          message: `versionDetailsMap key "${key}" (API version ${year}) cannot be greater than versionEnd (${endVersion}); that entry is ignored by sp-gateway.`,
-        });
-      }
-    }
-
-    return results;
-  },
-);
+// // Copyright (c) 2026. SailPoint Technologies, Inc. All rights reserved.
+// import { createOptionalContextRulesetFunction } from "./createOptionalContextRulesetFunction.js";
+// import { Route } from "./types.js";
+//
+// const V_YEAR_KEY = /^v(\d{4})$/;
+//
+// /**
+//  * Returns the numeric year for keys like v2026, or null for beta, v3, etc.
+//  */
+// function yearFromVersionDetailsKey(key: string): number | null {
+//     const m = V_YEAR_KEY.exec(key);
+//     return m ? parseInt(m[1], 10) : null;
+// }
+//
+// export default createOptionalContextRulesetFunction(
+//     {
+//         input: null,
+//         options: {},
+//     },
+//     (targetVal: Route) => {
+//         const results: { message: string }[] = [];
+//
+//         if (targetVal.versionEnd === undefined || targetVal.versionDetailsMap === undefined) {
+//             return results;
+//         }
+//
+//         const endVersion = targetVal.versionEnd;
+//         if (endVersion === 0) {
+//             return results;
+//         }
+//
+//         const map = targetVal.versionDetailsMap as unknown as Record<string, unknown>;
+//         for (const key of Object.keys(map)) {
+//             const year = yearFromVersionDetailsKey(key);
+//             if (year !== null && year > endVersion) {
+//                 results.push({
+//                     message: `versionDetailsMap key "${key}" (API version ${year}) cannot be greater than versionEnd (${endVersion}); that entry is ignored by sp-gateway.`,
+//                 });
+//             }
+//         }
+//
+//         return results;
+//     },
+// );

--- a/packages/gateway-rulesets/src/check-version-in-id-matches-path.ts
+++ b/packages/gateway-rulesets/src/check-version-in-id-matches-path.ts
@@ -1,0 +1,54 @@
+import {createOptionalContextRulesetFunction} from "./createOptionalContextRulesetFunction.js";
+import {Route} from "./types.js";
+
+export default createOptionalContextRulesetFunction(
+    {
+        input: null,
+        options: {
+        },
+    },
+    (route: Route, options: {}) => {
+        const versionPattern = /v\d$/
+        const internalPattern = /internal$/
+
+        let internalResults = checkVersionPattern(route.id, route.path, internalPattern);
+        if (internalResults.length > 0) {
+            return internalResults;
+        }
+
+        return checkVersionPattern(route.id, route.path, versionPattern);
+    },
+);
+
+function checkVersionPattern(id: string, path: string, versionPattern: RegExp) : {message: string}[] {
+    let results: {message: string}[] = [];
+
+    if (!versionPattern.test(id) && !versionPattern.test(path)) {
+        return results;
+    } else if ((!versionPattern.test(id) && versionPattern.test(path)) || (versionPattern.test(id) && !versionPattern.test(path))) {
+        results.push({
+            message: `route id and path must contain the same API version (eg. example-route-id-v1, example/path/v1)`
+        });
+        return results;
+    }
+
+    const pathVersionMatches = path.match(versionPattern);
+    if (!pathVersionMatches) {
+        results.push({
+            message: `path '${path}' must contain the API version of the route (eg. v1, v2, internal, etc.)`
+        });
+    } else {
+        if (pathVersionMatches?.length > 1) {
+            results.push({
+                message: `path '${path}' must contain only one API version (eg. v1, v2, internal, etc.)`
+            });
+        } else if (pathVersionMatches[0] !== id.split('-').at(-1)) {
+            results.push({
+                message: `the API version in '${path}' must match the API version of the route id: ${id.split('-').at(-1)}`
+            });
+        }
+    }
+
+    return results;
+}
+

--- a/packages/gateway-rulesets/src/check-version-in-id.ts
+++ b/packages/gateway-rulesets/src/check-version-in-id.ts
@@ -1,0 +1,22 @@
+import { createOptionalContextRulesetFunction } from "./createOptionalContextRulesetFunction.js";
+
+const versionPattern = /-v\d$/
+const internalPattern = /-internal$/
+
+export default createOptionalContextRulesetFunction(
+    {
+        input: null,
+        options: {
+        },
+    },
+    (routeId: string, options: {}) => {
+        let results = [];
+        if (!versionPattern.test(routeId) && !internalPattern.test(routeId)) {
+            results.push({
+                message: `route id must end with a version (eg. example-route-id-v1, example-route-id-internal)`
+            });
+        }
+        return results;
+    },
+);
+

--- a/packages/gateway-rulesets/src/check-version-start-order.ts
+++ b/packages/gateway-rulesets/src/check-version-start-order.ts
@@ -1,30 +1,30 @@
-import { createOptionalContextRulesetFunction } from "./createOptionalContextRulesetFunction.js";
-
-function countDigits(num:number) {
-    return String(num).split('').reduce(
-        (count) => count + 1, 0);
-}
-let isNonVersioned:boolean = false;
-// Create the original function using Spectral's helper.
-export default createOptionalContextRulesetFunction(
-    {
-        input: null,
-        options: {
-        },
-    },
-    (targetVal: number, options: { }) => {
-        let results = [];
-        let digitCount:number = countDigits(targetVal);
-
-        if(isNonVersioned && digitCount>=4){
-            results.push({
-                message: `versioned apis must be specified above non-versioned apis`
-            });
-        }else{
-            if(digitCount==1){
-                isNonVersioned = true;
-            }
-        }
-        return results;
-    },
-);
+// import { createOptionalContextRulesetFunction } from "./createOptionalContextRulesetFunction.js";
+//
+// function countDigits(num:number) {
+//     return String(num).split('').reduce(
+//         (count) => count + 1, 0);
+// }
+// let isNonVersioned:boolean = false;
+// // Create the original function using Spectral's helper.
+// export default createOptionalContextRulesetFunction(
+//     {
+//         input: null,
+//         options: {
+//         },
+//     },
+//     (targetVal: number, options: { }) => {
+//         let results = [];
+//         let digitCount:number = countDigits(targetVal);
+//
+//         if(isNonVersioned && digitCount>=4){
+//             results.push({
+//                 message: `versioned apis must be specified above non-versioned apis`
+//             });
+//         }else{
+//             if(digitCount==1){
+//                 isNonVersioned = true;
+//             }
+//         }
+//         return results;
+//     },
+// );

--- a/packages/gateway-rulesets/src/check-version-start.ts
+++ b/packages/gateway-rulesets/src/check-version-start.ts
@@ -1,25 +1,25 @@
-import { createOptionalContextRulesetFunction } from "./createOptionalContextRulesetFunction.js";
-
-// Create the original function using Spectral's helper.
-export default createOptionalContextRulesetFunction(
-    {
-        input: null,
-        options: {
-        },
-    },
-    (targetVal: number, options: { }) => {
-        let results = [];
-        if (!Number.isInteger(targetVal)) {
-            results.push({
-                message: `versionStart must be a number`
-            });
-        }
-        if (!(targetVal === 0 || 2024 <= targetVal)) {
-            results.push({
-                message: `versionStart must be 0 or higher than 2024`
-            });
-        }
-        return results;
-    },
-);
-
+// import { createOptionalContextRulesetFunction } from "./createOptionalContextRulesetFunction.js";
+//
+// // Create the original function using Spectral's helper.
+// export default createOptionalContextRulesetFunction(
+//     {
+//         input: null,
+//         options: {
+//         },
+//     },
+//     (targetVal: number, options: { }) => {
+//         let results = [];
+//         if (!Number.isInteger(targetVal)) {
+//             results.push({
+//                 message: `versionStart must be a number`
+//             });
+//         }
+//         if (!(targetVal === 0 || 2024 <= targetVal)) {
+//             results.push({
+//                 message: `versionStart must be 0 or higher than 2024`
+//             });
+//         }
+//         return results;
+//     },
+// );
+//

--- a/packages/gateway-rulesets/src/createOptionalContextRulesetFunction.ts
+++ b/packages/gateway-rulesets/src/createOptionalContextRulesetFunction.ts
@@ -1,7 +1,7 @@
 import {
-  createRulesetFunction as createSpectralFn,
-  RulesetFunction,
-  RulesetFunctionContext,
+    createRulesetFunction as createSpectralFn,
+    RulesetFunction,
+    RulesetFunctionContext,
 } from "@stoplight/spectral-core";
 
 /**
@@ -14,29 +14,29 @@ import {
  * @returns A wrapper function for the ruleset function.
  */
 export function createOptionalContextRulesetFunction<I, O>(
-  params: {
-    input: any;
-    options: any;
-  },
-  fn: RulesetFunction<I, O>,
+    params: {
+        input: any;
+        options: any;
+    },
+    fn: RulesetFunction<I, O>,
 ) {
-  // Create the original spectral function.
-  const originalFn = createSpectralFn(params, fn);
+    // Create the original spectral function.
+    const originalFn = createSpectralFn(params, fn);
 
-  // Return a wrapper that makes the third parameter (context) optional.
-  return ((
-    targetVal: I,
-    opts: O,
-    context?: Parameters<typeof originalFn>[2],
-  ) => {
-    return originalFn(
-      targetVal,
-      opts,
-      context || ({} as RulesetFunctionContext),
-    ); // default to an empty object if context is not provided.
-  }) as (
-    targetVal: I,
-    opts: O,
-    context?: Parameters<typeof originalFn>[2],
-  ) => ReturnType<typeof originalFn>;
+    // Return a wrapper that makes the third parameter (context) optional.
+    return ((
+        targetVal: I,
+        opts: O,
+        context?: Parameters<typeof originalFn>[2],
+    ) => {
+        return originalFn(
+            targetVal,
+            opts,
+            context || ({} as RulesetFunctionContext),
+        ); // default to an empty object if context is not provided.
+    }) as (
+        targetVal: I,
+        opts: O,
+        context?: Parameters<typeof originalFn>[2],
+    ) => ReturnType<typeof originalFn>;
 }

--- a/packages/gateway-rulesets/src/types.ts
+++ b/packages/gateway-rulesets/src/types.ts
@@ -14,15 +14,6 @@ export interface Route {
     // Backend service path, if not specified the path is used including the version. (optional)
     servicePath?: string;
 
-    // Integer version start indicates the starting version of API for example 2024. Should be set to 0 for non versionsed APIs for example /oauth (optional)
-    versionStart?: number;
-
-    // Version end indicates that the API should not be supported after a certain version (optional)
-    versionEnd?: number;
-
-    // Array of additional versions for eg. ["beta""v3"]. Default is []. (optional)
-    additionalVersions?: string[];
-
     // Override for the latest version mapping. If set, /latest will map to this version instead of the global latestVersion. (optional)
     latestVersionOverride?: number;
 
@@ -98,9 +89,6 @@ export interface Route {
     // Licenses that are required to access this route
     licenses?: string[];
 
-    // Properties can be overwritten for a version using this map.
-    versionDetailsMap?: Map<string, VersionDetails>;
-
     // AccessRights is an array of rights required to access this route. (optional)
     rights?: string[];
 
@@ -131,30 +119,9 @@ export interface BackOffConfig {
     redisTimeoutMs?: number;
 }
 
-export interface VersionDetails {
-    apiState?: string;
-    deprecation?: string;
-    // Service override for this version
-    service?: string;
-    // Backend service path override for this version
-    servicePath?: string;
-    // Feature flag to check to route to another service, for this version
-    featureFlag?: string;
-    // Service to route to when featureFlag is enabled, for this version
-    featureFlagServiceId?: string;
-    // Backend service path when featureFlag is enabled, for this version
-    featureFlagServicePath?: string;
-    // Feature flag specifies end of life date of an API, for this version
-    endOfLifeDateFeatureFlag?: string;
-    // Array of unauthenticated path prefixes for this version
-    unauthenticatedPaths?: string[];
-    // Add other VersionDetails properties as needed
-}
-
 export interface Subroute {
     rights?: string[];
     methods?: string[];
-    versions?: string[];
     rateLimit?: number;
     rateLimitIntervalSeconds?: number;
     // Per-method rate limiting configuration for this subroute. (optional)
@@ -192,7 +159,6 @@ export interface DynamicRateLimitCommonConfig {
 // Adding/removing a field from the interface, without also updating the types below, will cause a compiler error
 export type KeysEnum<T> = { [P in keyof Required<T>]: true };
 const RouteKeyType: KeysEnum<Route> = {
-    additionalVersions: true,
     apiState: true,
     backOffConfig: true,
     circuitBreakerEnabled: true,
@@ -226,27 +192,11 @@ const RouteKeyType: KeysEnum<Route> = {
     stripPrefixPath: true,
     subroutes: true,
     unauthenticatedPaths: true,
-    versionDetailsMap: true,
-    versionEnd: true,
-    versionStart: true
-}
-
-const VersionDetailsKeyType: KeysEnum<VersionDetails> = {
-    apiState: true,
-    deprecation: true,
-    service: true,
-    servicePath: true,
-    featureFlag: true,
-    featureFlagServiceId: true,
-    featureFlagServicePath: true,
-    endOfLifeDateFeatureFlag: true,
-    unauthenticatedPaths: true
 }
 
 const SubroutesKeyType: KeysEnum<Subroute> = {
     rights: true,
     methods: true,
-    versions: true,
     rateLimit: true,
     rateLimitIntervalSeconds: true,
     methodConfig: true
@@ -276,7 +226,6 @@ const BackOffConfigKeyType: KeysEnum<BackOffConfig> = {
 
 export const RouteKeys = Object.keys(RouteKeyType)
 export const SubrouteKeys = Object.keys(SubroutesKeyType)
-export const VersionDetailsKeys = Object.keys(VersionDetailsKeyType)
 export const RouteDynamicRateLimitConfigKeys = Object.keys(RouteDynamicRateLimitConfigKeyType)
 export const DynamicRateLimitCommonConfigKeys = Object.keys(DynamicRateLimitCommonConfigKeyType)
 export const BackOffConfigKeys = Object.keys(BackOffConfigKeyType)

--- a/packages/test-files/sp-gateway-routes.yaml
+++ b/packages/test-files/sp-gateway-routes.yaml
@@ -1,64 +1,60 @@
 sp-gateway:
   routes:
-    - id: "access-request-test"
-      path: "/access-request-path"
+    # Good routes
+    - id: "access-request-test-v1"
+      path: "/access-request-path/v1"
       service: "access-request-service"
-      versionStart: 2024
       servicePath: "/test/access-request-administration"
-      additionalVersions:
-      - "beta"
-      - "v3"
       routeType: "prefix"
       stripPrefix: true
+      stripPrefixPath: "/access-request-path/v1"
       apiState: "limited-preview"
 
-    - id: "subroute-test"
+    - id: "subroute-test-internal"
       service: "identity"
-      path: "/subroute-path"
+      path: "/subroute-path/internal"
       routeType: "prefix"
       stripPrefix: true
       apiState: "public"
-      versionStart: 2024
-      additionalVersions:
-        - "beta"
-        - "v3"
       subroutes:
         "/some/route/{id}":
           rights: ["some-right"]
           methods: ["GET", "POST"]
-          versions: ["v2024", "v2025", "beta", "v3"]
           rateLimit: 100
           rateLimitIntervalSeconds: 10
-      versionDetailsMap:
-        beta:
-          apiState: "public"
 
-    # Intentional violation: v2028 in versionDetailsMap is greater than versionEnd (2026) — expect gateway-route-version-details-map-keys-must-not-exceed-version-end
-    - id: "version-details-map-exceeds-version-end"
-      path: "/lint/version-details-map-vs-end"
-      service: "identity"
-      versionStart: 2024
-      versionEnd: 2026
+    # Bad routes - should return errors
+    - id: "access-request-test-internal"
+      path: "/access-request-path/v1"
+      service: "access-request-service"
+      servicePath: "/test/access-request-administration"
       routeType: "prefix"
       stripPrefix: true
-      apiState: "public"
-      versionDetailsMap:
-        v2028:
-          apiState: "public-preview"
+      stripPrefixPath: "/access-request-path/v1"
+      apiState: "limited-preview"
 
-    - id: "test-route"
-      path: "/test-path"
-      service: "identity"
-      versionStart: 0
+    - id: "access-request-test"
+      path: "/access-request-path/v1"
+      service: "access-request-service"
+      servicePath: "/test/access-request-administration"
       routeType: "prefix"
       stripPrefix: true
-      apiState: "public"
+      stripPrefixPath: "/access-request-path/v1"
+      apiState: "limited-preview"
+
+    - id: "access-request-test-v2"
+      path: "/access-request-path"
+      service: "access-request-service"
+      servicePath: "/test/access-request-administration"
+      routeType: "prefix"
+      stripPrefix: true
+      stripPrefixPath: "/access-request-path/v2"
+      apiState: "limited-preview"
 
     # Intentional violations for backOffConfig rules
-    - id: "back-off-config-test"
-      path: "/back-off-config-test"
+    - id: "back-off-config-test-v2"
+      path: "/back-off-config-test/v2"
       service: "identity"
-      versionStart: 2024
       routeType: "prefix"
       stripPrefix: true
       apiState: "public"


### PR DESCRIPTION
I commented out the yearly-versioned checks in case we need to re-enable them in the next few days.

# Manual Testing
I created some bad routes in sp-gateway-routes.yaml to generate these linter errors:
<img width="2175" height="176" alt="Screenshot 2026-06-17 at 11 02 00" src="https://github.com/user-attachments/assets/db0d9536-bcfd-4348-945f-443c37b2af78" />
